### PR TITLE
solve issue of low contrast

### DIFF
--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -54,7 +54,7 @@
             android:layout_weight="1"
             android:text="@string/select_file_btn"
             android:textAllCaps="false"
-            android:textColor="@color/main_button"
+            android:textColor="#3C3C3C"
             app:drawableTint="@color/main_button"
             app:drawableTopCompat="@drawable/ic_select_file" />
 


### PR DESCRIPTION
The original text color of the component is '#FFFFFF', and the contrast between the text color ('#FFFFFF') and the background color ('#52ACFF') does not meet the standard of WCAG 2.1. In other words, this color cannot be easily seen by everyone. So, to solve this problem, our team designed a tool that can automatically detect and repair such problems. The test report and recommended replacement colors ('#3C3C3C') are as follows:
![image](https://user-images.githubusercontent.com/101503193/211220810-d9c9a733-d13c-4b05-9434-7381a19e332f.png)
The figure on the left is the original page, the figure on the right is the repaired page, and the figure below is the problem detection report.
If you think it is useful, please give me feedback. Your feedback is very important to me. We sincerely hope to receive your suggestions and opinions as an app developer.